### PR TITLE
remove legacy variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,10 +66,6 @@ const extractCryptoPrice = (fatObject: CryptoCompareCurrentPriceEntry): CurrentP
     price: new BigNumber(fatObject.PRICE.toString()),
     lastUpdate: fatObject.LASTUPDATE,
     changePercent24h: new BigNumber(fatObject.CHANGEPCT24HOUR.toString()),
-    // TODO remove after flint release
-    PRICE: fatObject.PRICE,
-    LASTUPDATE: fatObject.LASTUPDATE,
-    CHANGEPCT24HOUR: fatObject.CHANGEPCT24HOUR,
   }
 }
 
@@ -231,11 +227,7 @@ const getPriceEndpoint = async (req: Request, res: Response) => {
         price: entry?.price.toPrecision(safeNumberPrecision),
         historyHourly: historyHourlyWeek[from as SupportedCurrencyFrom]?.[currTo].map(historyEntryToResult),
         historyDaily: historyDailyAll[from as SupportedCurrencyFrom]?.[currTo].map(historyEntryToResult),
-        // TODO remove after Flint release    
-        PRICE: entry?.PRICE,
-        LASTUPDATE: entry?.LASTUPDATE,
-        CHANGEPCT24HOUR: entry?.CHANGEPCT24HOUR,
-      }
+        }
     ]})
   )
   res.send(result)

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -6,14 +6,7 @@ export type CryptoCompareCurrentPriceEntry = {
   CHANGEPCT24HOUR: number,
 }
 
-// TODO: remove after Flint release
-type LegacyCurrentPriceEntry = {
-  PRICE: number,
-  LASTUPDATE: number,
-  CHANGEPCT24HOUR: number,
-}
-
-export type CurrentPriceEntry = LegacyCurrentPriceEntry & {
+export type CurrentPriceEntry = {
     price: BigNumber,
     lastUpdate: number,
     changePercent24h: BigNumber,


### PR DESCRIPTION
https://app.shortcut.com/dcspark/story/2079/send-price-as-string

1. original change is deployed
2. Flint change is merged, waiting to deploy
3. This should wait for Flint change to deploy and get adopted (at least a few weeks after deploymet, no need to rush)